### PR TITLE
Improved printing behavior

### DIFF
--- a/script_builtins.js
+++ b/script_builtins.js
@@ -31,6 +31,7 @@ function BuiltIns() {
   this.variables = [
     {name: "E",        type: classMap.get("Double"), scope: classMap.get("Math"), js: "Math.E"},
     {name: "PI",       type: classMap.get("Double"), scope: classMap.get("Math"), js: "Math.PI"},
+    {name: "non-breaking space", type: classMap.get("String"), scope: classMap.get("System"), js: '"\xa0"'},
   ].reverse();
   
   function parseFunction(js, returnType, scope, name, ...parameters) {

--- a/ui.js
+++ b/ui.js
@@ -680,8 +680,21 @@ function* stride(start, end, by) {
 }
 
 function print(value, terminator) {
-  const text = document.createTextNode(String(value) + terminator);
-  consoleOutput.appendChild(text);
+  const text = String(value) + terminator;
+  const segments = text.split("\n");
+  const lastSegment = segments.pop();
+
+  for (const segment of segments) {
+    const textNode = document.createTextNode(segment);
+    const lineBreak = document.createElement("BR");
+    consoleOutput.appendChild(textNode);
+    consoleOutput.appendChild(lineBreak);
+  }
+
+  if (lastSegment) {
+    const textNode = document.createTextNode(lastSegment);
+    consoleOutput.appendChild(textNode);
+  }
 }
 
 // let httpRequest = new XMLHttpRequest();


### PR DESCRIPTION
Printing now replaces \n chars with <br> elements so <pre-wrap> doesn't break long lines on the last character.  The old behavior resulted in lines too wide to fit on screen having their \n char inserted on the following line.

Filling out a row now correctly updates the list height to allow further scrolling.