### PR TITLE
Changed word wrapping of console output

### DIFF
--- a/main.css
+++ b/main.css
@@ -177,6 +177,9 @@ button {
 }
 .string-literal {
   color: #A5C25C;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .comment {
   color: #808080;
@@ -286,7 +289,7 @@ button {
 }
 
 #console-output {
-  white-space: pre-wrap;
+  white-space: pre;
   font-family: monospace;
   color: white;
   margin: 0px;
@@ -294,6 +297,10 @@ button {
   box-sizing: border-box;
   width: 100%;
   height: 100%;
+}
+
+span.wordwrap {
+  white-space: pre-wrap;
 }
 
 #list {

--- a/script.js
+++ b/script.js
@@ -1419,7 +1419,7 @@ class Script {
 
       case Script.LITERAL: {
         if (meta === 1)
-          return [`"${this.literals.get(value)}"`, "string-literal"];
+        return [`"${this.literals.get(value)}"`, "string-literal"];
         else
           return [this.literals.get(value), "literal"];
       }

--- a/script.js
+++ b/script.js
@@ -204,6 +204,8 @@ class Script {
     this.BINARY_OPERATORS = new Operator(11, 31);
     this.UNARY_OPERATORS = new Operator(35, 38);
     this.OPERATORS = new Operator(0, 38);
+    this.ARITHMETIC_OPERATORS = new Operator(11, 23);
+    this.COMPARRISON_OPERATORS = new Operator(25, 31);
 
     this.UNARY_OPERATORS.postfix = " ____"
   }
@@ -417,12 +419,14 @@ class Script {
       || data.format === Script.LITERAL
       || item === this.ITEMS.END_PARENTHESIS) {
         options.push( {text: "( )", style: "", payload: this.PAYLOADS.WRAP_IN_PARENTHESIS} );
-        options.push(...this.BINARY_OPERATORS.getMenuItems());
+        options.push(...this.ARITHMETIC_OPERATORS.getMenuItems());
+        options.push(...this.COMPARRISON_OPERATORS.getMenuItems());
       }
       else if (prevData.format === Script.VARIABLE_REFERENCE
       || prevData.format === Script.LITERAL
       || prevItem === this.ITEMS.END_PARENTHESIS) {
-        options.push(...this.BINARY_OPERATORS.getMenuItems());
+        options.push(...this.ARITHMETIC_OPERATORS.getMenuItems());
+        options.push(...this.COMPARRISON_OPERATORS.getMenuItems());
       }
 
       if (item !== this.ITEMS.IF && prevItem === this.ITEMS.ELSE) {

--- a/script_builtins.js
+++ b/script_builtins.js
@@ -119,8 +119,8 @@ function BuiltIns() {
     "==", //comparison operators
     "!=",
     ">",
-    ">=",
     "<",
+    ">=",
     "<=",
     "+", //string concatenation
     "*", //string repetition

--- a/script_builtins.js
+++ b/script_builtins.js
@@ -87,7 +87,7 @@ function BuiltIns() {
     parseFunction("Math.round", "Double", "Math", "round", "Double", "number", undefined),
     parseFunction("Math.floor", "Double", "Math", "floor", "Double", "number", undefined),
     parseFunction("Math.ceil", "Double", "Math", "ceil", "Double", "number", undefined),
-    parseFunction("print", "void", "System", "print", "Any", "item", "", "String", "terminator", "\n"),
+    parseFunction("print", "void", "System", "print", "Any", "item", "", "String", "terminator", "\n", "Boolean", "word wrap", false),
   ].reverse();
   
   this.symbols = [

--- a/ui.js
+++ b/ui.js
@@ -748,20 +748,15 @@ function* stride(start, end, by) {
   }
 }
 
-function print(value, terminator) {
-  const text = String(value) + terminator;
-  const segments = text.split("\n");
-  const lastSegment = segments.pop();
+function print(value, terminator, wordWrap) {
+  const textNode = document.createTextNode(value + terminator);
 
-  for (const segment of segments) {
-    const textNode = document.createTextNode(segment);
-    const lineBreak = document.createElement("BR");
-    consoleOutput.appendChild(textNode);
-    consoleOutput.appendChild(lineBreak);
-  }
-
-  if (lastSegment) {
-    const textNode = document.createTextNode(lastSegment);
+  if (wordWrap) {
+    const span = document.createElement("SPAN");
+    span.classList.add('wordwrap');
+    span.appendChild(textNode);
+    consoleOutput.appendChild(span);
+  } else {
     consoleOutput.appendChild(textNode);
   }
 }

--- a/ui.js
+++ b/ui.js
@@ -246,8 +246,8 @@ function selectProject(event) {
     localStorage.setItem(ACTIVE_PROJECT_KEY, projectID);
     script = new Script();
     reloadAllRows();
-    closeMenu();
   }
+  closeMenu();
   window.history.back();
 }
 


### PR DESCRIPTION
Users now opt into word wrapping on every call to System.print() rather than being forced to use non-breaking spaces to prevent word wrap.  This prevents Safari from breaking on a '\n' character and inserting an extra blank line after long whitespace-less lines of output.

String literals are truncated after 200px so long string literals are easier to work with.

Hid === and !== again.

Moved "<" operator above ">=" operator in menu.

The menu closes when switching projects.