### PR TITLE
Minor menu corrections

### DIFF
--- a/script.js
+++ b/script.js
@@ -95,9 +95,9 @@ class Script {
 
     this.ITEMS.EQUALS              = makeSymbol("=");
     this.ITEMS.START_SUBEXPRESSION = makeSymbol("(");
+    this.ITEMS.START_ARGUMENTS     = this.ITEMS.START_SUBEXPRESSION + 1;
     this.ITEMS.END_SUBEXPRESSION   = makeSymbol(")");
-    this.ITEMS.START_ARGUMENTS     = makeSymbol("⟨");
-    this.ITEMS.END_ARGUMENTS       = makeSymbol("⟩");
+    this.ITEMS.END_ARGUMENTS       = this.ITEMS.END_SUBEXPRESSION + 1;
     this.ITEMS.COMMA               = makeSymbol(",");
     this.ITEMS.UNDERSCORE          = makeSymbol("____");
 
@@ -588,7 +588,7 @@ class Script {
       this.spliceRow(row, start, end - start + 1, ...replacementItems);
       
       if (oldItemCount === 1)
-        return {rowUpdated: true, rowsInserted: 1};
+        return {rowUpdated: true, rowsInserted: 1, selectedCol: start + 2};
       else
         return {rowUpdated: true, selectedCol: start + 2};
     }

--- a/script_builtins.js
+++ b/script_builtins.js
@@ -140,12 +140,12 @@ function BuiltIns() {
     "?", //first part of ternary conditional operator
     ":", //second part of ternary conditional operator
     "(", //subexpression start
-    "⟨", //function arguments start
+    "(", //function arguments start
     "[", //subscript start
     "【", //array literal start
     "{", //dictionary literal start
     ")", //subexpression end
-    "⟩", //function arguments end
+    ")", //function arguments end
     "]", //subscript end
     "】", //array literal end
     "}", //dictionary literal end


### PR DESCRIPTION
Picking a function call and discarding output now selects the
first argument

Arguments are wrapped in parenthesis since the symbol needs to be parsed
as javascript.
-This was a silly oversight